### PR TITLE
Fix xemu table being overwritten by "cross emu - mesen.lua"

### DIFF
--- a/cross emu - mesen.lua
+++ b/cross emu - mesen.lua
@@ -1,7 +1,7 @@
 -- Emus that use an old version of lua choke on parsing these bitwise operators, but Mesen doesn't have a bit operator library,
 -- so I've had to move this code out into a separate file that's conditionally included
 
-xemu = {}
+local xemu = {}
 xemu.rshift = function(x, y) return x >> y end
 xemu.lshift = function(x, y) return x << y end
 xemu.not_ = function(x) return ~x end


### PR DESCRIPTION
The `xemu = {}` assignment in "cross emu - mesen.lua" was clobbering the global `xemu` table from the including script, causing the `emuId` field to get removed and breaking the rest of the script.